### PR TITLE
Adding aio-lib-core-networking to core sdk

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ This is the Adobe I/O Core SDK. This contains:
 - [Core Errors Library](https://github.com/adobe/aio-lib-core-errors)
 - [Core Logger Library](https://github.com/adobe/aio-lib-core-logging)
 - [Core TVM Library](https://github.com/adobe/aio-lib-core-tvm)
+- [Core Networking Library](https://github.com/adobe/aio-lib-core-netwroking)
 
 [SDK Health](./health.md)
 
@@ -36,7 +37,7 @@ Here is a snippet:
 ```javascript
 const CoreSdk = require('@adobe/aio-sdk-core')
 // OR ...
-const { Config, Errors, TVMClient, Logger } = require('@adobe/aio-sdk-core')
+const { Config, Errors, TVMClient, Logger, HttpClient } = require('@adobe/aio-sdk-core')
 
 // set a Config key value
 CoreSdk.Config.set('my.token', 1234)
@@ -53,6 +54,10 @@ const tvm = await CoreSdk.TVMClient.init({ ow: { auth: '<myauth>', namespace: '<
 // create a Logger
 const myAppLogger = CoreSdk.Logger('MyApp')
 myAppLogger.info('Hello, Dave.')
+
+// create own reference variable to call HttpClient for exponential backoff
+const httpClient = CoreSdk.HttpClient
+const response = await httpClient.exponentialBackoff('url', {method: 'GET'})
 ```
 
 ## Explore

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ This is the Adobe I/O Core SDK. This contains:
 - [Core Errors Library](https://github.com/adobe/aio-lib-core-errors)
 - [Core Logger Library](https://github.com/adobe/aio-lib-core-logging)
 - [Core TVM Library](https://github.com/adobe/aio-lib-core-tvm)
-- [Core Networking Library](https://github.com/adobe/aio-lib-core-netwroking)
+- [Core Networking Library](https://github.com/adobe/aio-lib-core-networking)
 
 [SDK Health](./health.md)
 

--- a/package.json
+++ b/package.json
@@ -18,7 +18,8 @@
     "@adobe/aio-lib-core-config": "^1.0.15",
     "@adobe/aio-lib-core-errors": "^3.0.0",
     "@adobe/aio-lib-core-logging": "^1.1.0",
-    "@adobe/aio-lib-core-tvm": "^1.0.3"
+    "@adobe/aio-lib-core-tvm": "^1.0.3",
+    "@adobe/aio-lib-core-networking": "^1.0.0"
   },
   "devDependencies": {
     "codecov": "^3.6.1",

--- a/src/index.js
+++ b/src/index.js
@@ -13,6 +13,7 @@ const Errors = require('@adobe/aio-lib-core-errors')
 const Config = require('@adobe/aio-lib-core-config')
 const TVMClient = require('@adobe/aio-lib-core-tvm')
 const Logger = require('@adobe/aio-lib-core-logging')
+const HttpClient = require('@adobe/aio-lib-core-networking')
 
 /** @module @adobe/aio-sdk-core */
 module.exports = {
@@ -39,5 +40,11 @@ module.exports = {
    *
    * @see {@link https://github.com/adobe/aio-lib-core-logging/blob/master/README.md|@adobe/aio-lib-core-logging}
    */
-  Logger
+  Logger,
+  /**
+   *  The Networking Module of the Adobe I/O Core SDK
+   *
+   * @see {@link https://github.com/adobe/aio-lib-core-networking/blob/master/README.md|@adobe/aio-lib-core-networking}
+   */
+  HttpClient
 }

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -16,4 +16,5 @@ test('module existence', () => {
   expect(core.Errors).toBeTruthy()
   expect(core.TVMClient).toBeTruthy()
   expect(core.Logger).toBeTruthy()
+  expect(core.HttpClient).toBeTruthy()
 })


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->
aio-lib-core-networking implements fetch with exponential backoff and default retries on 5xx and network errors. This can be used by other aio lib sdks. 

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.